### PR TITLE
Turn ProxyRequests off

### DIFF
--- a/templates/default/loadBalancer/httpd.conf.erb
+++ b/templates/default/loadBalancer/httpd.conf.erb
@@ -1022,7 +1022,7 @@ BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 #</VirtualHost>
 
   <IfModule mod_proxy.c>
-    ProxyRequests On
+    ProxyRequests Off
     ProxyPassReverse / balancer://alf/
 
     ProxyPass /balancer-manager !


### PR DESCRIPTION
A reverse proxy is activated using the ProxyPass directive or the [P] flag to the RewriteRule directive. 

It is not necessary to turn ProxyRequests on in order to configure a reverse proxy.
